### PR TITLE
Add legacy pack format

### DIFF
--- a/dist/src/main/kotlin/kr/toxicity/hud/pack/PackMeta.kt
+++ b/dist/src/main/kotlin/kr/toxicity/hud/pack/PackMeta.kt
@@ -45,9 +45,9 @@ data class PackMeta(
         val default by lazy {
             PackMeta(
                 Pack(
-                    BOOTSTRAP.mcmetaVersion(),
+                    PackOverlay.LEGACY.minVersion,
                     "BetterHud's default resource pack.",
-                    VersionRange(9, 99)
+                    VersionRange(PackOverlay.LEGACY.minVersion, 99)
                 ),
                 Overlay(PackOverlay.entries.filter {
                     it.ordinal > 0

--- a/dist/src/main/kotlin/kr/toxicity/hud/pack/PackOverlay.kt
+++ b/dist/src/main/kotlin/kr/toxicity/hud/pack/PackOverlay.kt
@@ -7,7 +7,7 @@ enum class PackOverlay(
     val minVersion: Int,
     val maxVersion: Int
 ) {
-    LEGACY("betterhud_legacy", 9, 34),
+    LEGACY("betterhud_legacy", 6, 34),
     V1_21_2("betterhud_1_21_2", 35, 45),
     V1_21_4("betterhud_1_21_4", 46, 55),
     V1_21_6("betterhud_1_21_6", 56, 99)


### PR DESCRIPTION
## Summary
- extend `PackOverlay.LEGACY` down to pack format 6
- use the legacy format as the default pack.mcmeta version

## Testing
- `./gradlew build -x test` *(fails: Plugin [id: 'fabric-loom'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a60a96d9883259b6ca5e985b48a36